### PR TITLE
Replace Red Hat OpenJDK with Azul Zulu OpenJDK 17

### DIFF
--- a/k8ssandra/5.0/Dockerfile
+++ b/k8ssandra/5.0/Dockerfile
@@ -7,6 +7,16 @@ ARG TARGETARCH
 
 USER root
 COPY axonops-yum-repo.repo /etc/yum.repos.d/axonops-yum.repo
+
+# Replace Red Hat OpenJDK with Azul Zulu OpenJDK 17 (supports Shenandoah GC)
+RUN microdnf remove -y java-17-openjdk-headless && \
+    rpm -ivh https://cdn.azul.com/zulu/bin/zulu-repo-1.0.0-2.noarch.rpm && \
+    microdnf install -y zulu17-jdk && \
+    microdnf remove -y zulu-repo && \
+    microdnf clean all && \
+    rm -rf /var/cache/yum /var/cache/dnf
+
+# Install AxonOps agents and configure
 RUN groupadd --gid 9988 axonops && \
     useradd --gid 9988 --uid 9988 --shell /bin/bash -c "AxonOps" -G cassandra axonops && \
     usermod -aG axonops cassandra && \


### PR DESCRIPTION
# Replace Red Hat OpenJDK with Azul Zulu OpenJDK 17

## Overview

Replaces the default Red Hat OpenJDK with Azul Zulu OpenJDK 17, which is the AxonOps recommended JDK for Cassandra 5.0 due to Shenandoah GC support and performance optimizations.

## Changes

### Dockerfile (k8ssandra/5.0/Dockerfile)
- Remove `java-17-openjdk-headless` package (~206MB freed)
- Install Azul Zulu repository via RPM
- Install `zulu17-jdk` package (~125MB)
- Remove zulu-repo after installation
- Clean package caches

## Benefits

- **Shenandoah GC support:** Low-latency garbage collector (AxonOps recommendation)
- **Performance:** Azul-specific JVM optimizations
- **Same version:** JDK 17.0.17 LTS (maintains compatibility)
- **Multi-arch:** Supports both x86_64 and aarch64
- **Container size:** Net reduction (~80MB saved)

## Testing

Tested locally with podman:
- ✅ Build succeeds
- ✅ Java version: `Zulu17.62+17-CA`
- ✅ Shenandoah GC available: `-XX:+UseShenandoahGC` flag works

## Configuration

No configuration changes needed - Azul Zulu is a drop-in replacement for Red Hat OpenJDK.
Same JDK version and API compatibility.

## Reference

- Azul Zulu documentation: https://docs.azul.com/core/install/linux-ca-rpm
- Package: zulu17-jdk (JDK 17 with full toolset)