### PR TITLE
Fix: Add missing build args to publish workflow

### DIFF
--- a/.github/workflows/k8ssandra-publish-signed.yml
+++ b/.github/workflows/k8ssandra-publish-signed.yml
@@ -128,6 +128,8 @@ jobs:
             GIT_TAG=${{ inputs.main_git_tag }}
             GITHUB_ACTOR=${{ github.actor }}
             CQLAI_VERSION=${{ vars.K8SSANDRA_CQLAI_VERSION }}
+            IS_PRODUCTION_RELEASE=true
+            IMAGE_FULL_NAME=ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}-test
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -319,6 +321,8 @@ jobs:
             GIT_TAG=${{ inputs.main_git_tag }}
             GITHUB_ACTOR=${{ github.actor }}
             CQLAI_VERSION=${{ vars.K8SSANDRA_CQLAI_VERSION }}
+            IS_PRODUCTION_RELEASE=true
+            IMAGE_FULL_NAME=ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}-v${{ steps.k8ssandra.outputs.k8ssandra_api_version }}-${{ inputs.container_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -350,6 +354,8 @@ jobs:
             GIT_TAG=${{ inputs.main_git_tag }}
             GITHUB_ACTOR=${{ github.actor }}
             CQLAI_VERSION=${{ vars.K8SSANDRA_CQLAI_VERSION }}
+            IS_PRODUCTION_RELEASE=true
+            IMAGE_FULL_NAME=ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}-v${{ steps.k8ssandra.outputs.k8ssandra_api_version }}-${{ inputs.container_version }}
           cache-from: type=gha
 
       - name: Image published and signed


### PR DESCRIPTION
## Summary

This PR fixes missing build args in the production publish workflow that are required by the Dockerfiles.

## Problem

The  workflow was not passing two required build args:
- `IS_PRODUCTION_RELEASE` - Used to control banner output (show release link, image name, etc.)
- `IMAGE_FULL_NAME` - Used for OCI label `org.opencontainers.image.ref.name` and banner display

## Solution

Added both build args to all three build steps in the workflow:
1. Test build step
2. Main build and push step
3. Re-push after signing step

## Values Set
- `IS_PRODUCTION_RELEASE=true` (identifies production releases)
- `IMAGE_FULL_NAME=ghcr.io/axonops/k8ssandra/cassandra:{version}` (full 3D tag)

## Impact

With this fix, production builds will:
- ✅ Show complete banner with Image, Release, Built by fields
- ✅ Have `org.opencontainers.image.ref.name` OCI label populated
- ✅ Be properly identified as production releases in logs

## Testing

Ready to test with production release workflow.