### PR TITLE
Fix TLS not being disabled when requested

### DIFF
--- a/axonops/charts/axondb-search/Chart.yaml
+++ b/axonops/charts/axondb-search/Chart.yaml
@@ -37,4 +37,4 @@ version: 0.2.7
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "3.3.2-1.1.0"
+appVersion: "3.3.2-1.4.0"


### PR DESCRIPTION
## Summary
- Fix TLS/SSL not being properly disabled when `tls.enabled=false` is set
- Update entrypoint script to completely disable SSL based on configuration
- Add default issuer template for cert-manager
- Bump chart versions

## Changes
- Modified entrypoint.sh to properly handle TLS disable flag
- Added issuer.yaml template for cert-manager integration
- Updated Dockerfile with TLS-related improvements
- Bumped chart versions for axondb-search and axonops

## Commits
- TLS for search not disabled as requested
- Fully disable TLS
- Fully disable TLS - fixes on sed command
- Completely disable SSL if requested
- Default issuer
- Bump up chart for search

## Test plan
- [ ] Deploy with `tls.enabled=false` and verify SSL is completely disabled
- [ ] Deploy with `tls.enabled=true` and verify SSL works correctly
- [ ] Verify cert-manager integration with new issuer template