### PR TITLE
Remove unnecessary podManagementPolicy config from axon-server StatefulSet

### DIFF
--- a/axonops/charts/axon-server/README.md
+++ b/axonops/charts/axon-server/README.md
@@ -977,7 +977,6 @@ curl http://localhost:8080/api/v1/healthz
 | persistence.storageClass | string | `""` | Storage class name |
 | podAnnotations | object | `{}` | Pod annotations |
 | podLabels | object | `{}` | Pod labels |
-| podManagementPolicy | string | `"OrderedReady"` | Pod management policy |
 | podSecurityContext.enabled | bool | `false` | Enable pod security context |
 | podSecurityContext.fsGroup | int | `9988` | FSGroup for pod |
 | podSecurityContext.runAsNonRoot | bool | `true` | Run as non-root |

--- a/axonops/charts/axon-server/templates/statefulset.yaml
+++ b/axonops/charts/axon-server/templates/statefulset.yaml
@@ -10,7 +10,6 @@ spec:
     matchLabels:
       {{- include "axon-server.selectorLabels" . | nindent 6 }}
   serviceName: {{ include "axon-server.fullname" . }}
-  podManagementPolicy: {{ .Values.podManagementPolicy }}
   updateStrategy:
     {{- toYaml .Values.updateStrategy | nindent 4 }}
   template:

--- a/axonops/charts/axon-server/values.yaml
+++ b/axonops/charts/axon-server/values.yaml
@@ -316,9 +316,6 @@ persistence:
 updateStrategy:
   type: RollingUpdate
 
-# Pod management policy for StatefulSet
-podManagementPolicy: OrderedReady
-
 # vals-operator integration for external secret management
 # See VALS_OPERATOR.md for usage instructions
 vals:


### PR DESCRIPTION
## Summary

- Removes the configurable `podManagementPolicy` from the axon-server StatefulSet
- Removes the value from `values.yaml` and documentation from `README.md`

## Rationale

Since the axon-server StatefulSet only runs a single replica, the `podManagementPolicy` setting is irrelevant. Kubernetes defaults to `OrderedReady` which is the desired behavior for single-pod StatefulSets.

Removing this configurable option simplifies the Helm chart without any functional impact.

Fixes #88

## Test plan

- [ ] Verify the chart still deploys correctly with `helm template`
- [ ] Confirm the StatefulSet uses the default `OrderedReady` policy