### PR TITLE
allow axon user to chown data directories

### DIFF
--- a/k8ssandra/4.0/Dockerfile
+++ b/k8ssandra/4.0/Dockerfile
@@ -89,6 +89,7 @@ RUN groupadd --gid 9988 axonops && \
     rm -f /etc/axonops/axon-agent.yml && \
     touch /var/run/utmp && \
     microdnf clean all && \
+    setcap cap_chown+eip /usr/share/axonops/axon-agent && \
     rm -rf /var/cache/yum /var/cache/dnf
 
 # Install cqlai (pinned version - must be provided as build arg)

--- a/k8ssandra/4.1/Dockerfile
+++ b/k8ssandra/4.1/Dockerfile
@@ -89,6 +89,7 @@ RUN groupadd --gid 9988 axonops && \
     rm -f /etc/axonops/axon-agent.yml && \
     touch /var/run/utmp && \
     microdnf clean all && \
+    setcap cap_chown+eip /usr/share/axonops/axon-agent && \
     rm -rf /var/cache/yum /var/cache/dnf
 
 # Install cqlai (pinned version - must be provided as build arg)

--- a/k8ssandra/5.0/Dockerfile
+++ b/k8ssandra/5.0/Dockerfile
@@ -88,7 +88,9 @@ RUN groupadd --gid 9988 axonops && \
     chmod 755 /usr/share/axonops/axon-agent && \
     rm -f /etc/axonops/axon-agent.yml && \
     touch /var/run/utmp && \
-    microdnf clean all
+    microdnf clean all && \
+    setcap cap_chown+eip /usr/share/axonops/axon-agent && \
+    rm -rf /var/cache/yum /var/cache/dnf
 
 # Install cqlai (pinned version - must be provided as build arg)
 ARG CQLAI_VERSION


### PR DESCRIPTION
This is needed for the restoration process. Seeing this right now:

```
restoring table system_distributed.repair_history RestoreBackup ChangePathOwnership /opt/cassandra/data/data: failed to chown recursively host path: lchown /opt/cassandra/data/data: operation not permitted RestoreBackup ChangePathOwnership /opt/cassandra/data/data: failed to chown recursively host path: lchown /opt/cassandra/data/data: operation not permitted
```