### PR TITLE
workaround commit log archiver race condition

### DIFF
--- a/k8ssandra/4.0/Dockerfile
+++ b/k8ssandra/4.0/Dockerfile
@@ -88,7 +88,9 @@ RUN groupadd --gid 9988 axonops && \
     chmod 755 /usr/share/axonops/axon-agent && \
     rm -f /etc/axonops/axon-agent.yml && \
     touch /var/run/utmp && \
+    mkdir -p /var/lib/axonops/cassandra && \
     echo '{"working_dir": "/opt/cassandra","commit_log_dir": "/opt/cassandra/data/commitlog"}' > /var/lib/axonops/cassandra/cassandra_info.json && \
+    chown -R cassandra:cassandra /var/lib/axonops/cassandra && \
     microdnf clean all && \
     setcap cap_chown,cap_fowner+eip /usr/share/axonops/axon-agent && \
     rm -rf /var/cache/yum /var/cache/dnf

--- a/k8ssandra/4.1/Dockerfile
+++ b/k8ssandra/4.1/Dockerfile
@@ -88,7 +88,9 @@ RUN groupadd --gid 9988 axonops && \
     chmod 755 /usr/share/axonops/axon-agent && \
     rm -f /etc/axonops/axon-agent.yml && \
     touch /var/run/utmp && \
+    mkdir -p /var/lib/axonops/cassandra && \
     echo '{"working_dir": "/opt/cassandra","commit_log_dir": "/opt/cassandra/data/commitlog"}' > /var/lib/axonops/cassandra/cassandra_info.json && \
+    chown -R cassandra:cassandra /var/lib/axonops/cassandra && \
     microdnf clean all && \
     setcap cap_chown,cap_fowner+eip /usr/share/axonops/axon-agent && \
     rm -rf /var/cache/yum /var/cache/dnf

--- a/k8ssandra/5.0/Dockerfile
+++ b/k8ssandra/5.0/Dockerfile
@@ -88,7 +88,9 @@ RUN groupadd --gid 9988 axonops && \
     chmod 755 /usr/share/axonops/axon-agent && \
     rm -f /etc/axonops/axon-agent.yml && \
     touch /var/run/utmp && \
+    mkdir -p /var/lib/axonops/cassandra && \
     echo '{"working_dir": "/opt/cassandra","commit_log_dir": "/opt/cassandra/data/commitlog"}' > /var/lib/axonops/cassandra/cassandra_info.json && \
+    chown -R cassandra:cassandra /var/lib/axonops/cassandra && \
     microdnf clean all && \
     setcap cap_chown,cap_fowner+eip /usr/share/axonops/axon-agent && \
     rm -rf /var/cache/yum /var/cache/dnf


### PR DESCRIPTION
Because the agent is started before Cassandra, there is a race condition where `/var/lib/axonops/cassandra/cassandra_info.json` is never created. Since we know the paths of the Dockerfile, we should create these ourselves.

cassandra_agent/#110 should fix the race condition, but this PR unblocks us now and looks ideal.