### PR TITLE
feat(containers): axon-agent supervision, Strimzi v1 examples, k8ssandra version script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,3 +28,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Default Cassandra version bumped to 5.0.8 in all workflow inputs that previously defaulted to 5.0.6 or 5.0.7.
 - `k8ssandra-development-publish-signed.yml` `:latest` and `:5.0-latest` tags now point to 5.0.8 (previously 5.0.6).
 - Updated `axondb-timeseries/.trivyignore` comment for CVE-2026-27314 to note it is fixed in 5.0.7+ and retained only for older matrix versions.
+- Bumped the Strimzi example manifests (`examples/strimzi/{cloud,local-disk,on-premises}/*.yaml`) from `apiVersion: kafka.strimzi.io/v1beta2` to `kafka.strimzi.io/v1` for the `Kafka`, `KafkaConnect` and `KafkaNodePool` resources. The `v1` API is served by Strimzi operator ≥0.49.0 and is the only version served from 1.0.1 onwards (where `v1beta2` is dropped), so this keeps the examples working against the newly added 1.0.1/1.1.0 operators. Requires Strimzi operator ≥0.49.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Cassandra 5.0.7 added to `k8ssandra-build-and-test` secondary version matrix.
 - Cassandra 5.0.8 support across k8ssandra and AxonDB TimeSeries CI workflows: build-and-test, nightly security scan, publish-signed, development-publish-signed, e2e-test, cloud-install-test, backups-publish-signed.
 - New `axonops/axondb-timeseries/5.0.8/` Dockerfile directory for AxonDB TimeSeries images.
+- New helper script `k8ssandra/scripts/set_latest_k8ssandra_version.sh` that reads the `K8SSANDRA_VERSIONS` GitHub Actions repository variable and sets `K8SSANDRA_VERSION` to the highest Cassandra semver found. Supports `--repo OWNER/REPO` and `--dry-run`; requires the `gh` CLI and `jq`.
 
 ### Fixed
 - Bumped all k8ssandra base images from `cass-management-api v0.1.113` to `v0.1.120` (newer UBI 9 base), resolving unignored CRITICAL/HIGH CVEs detected by the nightly Trivy scan.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Process supervision and automatic restart for the `axon-agent` sidecar process in the k8ssandra (`k8ssandra/{4.0,4.1,5.0}/axonops-entrypoint.sh`) and strimzi (`strimzi/files/axonops-wrapper.sh`) container images. If the agent exits it is now restarted automatically, with crash-loop protection (>5 restarts in 60s triggers a 30s backoff) and death/restart events logged to stdout and `/var/log/axonops/axon-agent.log`. Previously a dead agent was never detected or restarted for the life of the container ([#154](https://github.com/axonops/axonops-containers/issues/154)).
 - Strimzi operator 0.51.0, 1.0.1 and 1.1.0 added to the build matrix across all four strimzi CI workflows (`strimzi-build-and-test`, `strimzi-development-build-and-test`, `strimzi-publish-signed`, `strimzi-development-publish-signed`), with pinned base-image digests and `VERSION_MATRIX` entries. Supported Kafka versions: 0.51.0 → 4.1.0/4.1.1/4.2.0; 1.0.1 → 4.1.0/4.1.1/4.1.2/4.2.0; 1.1.0 → 4.2.0/4.2.1/4.3.0.
 - OpenSearch 3.7.0 support: new `axonops/axondb-search/opensearch/3.7.0/` Dockerfile directory.
 - OpenSearch 3.7.0 added to the `axondb-search-build-and-test` and `axondb-search-development-publish-signed` CI matrix alongside 3.3.2.
@@ -23,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Changed
+- k8ssandra 4.0/4.1 containers no longer exit when `axon-agent` dies; the agent is now restarted under supervision and the container lifecycle is tied to the Management API only (matching 5.0 behaviour).
 - Default Cassandra version bumped to 5.0.8 in all workflow inputs that previously defaulted to 5.0.6 or 5.0.7.
 - `k8ssandra-development-publish-signed.yml` `:latest` and `:5.0-latest` tags now point to 5.0.8 (previously 5.0.6).
 - Updated `axondb-timeseries/.trivyignore` comment for CVE-2026-27314 to note it is fixed in 5.0.7+ and retained only for older matrix versions.

--- a/examples/strimzi/cloud/kafka-cluster.yaml
+++ b/examples/strimzi/cloud/kafka-cluster.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: ${STRIMZI_CLUSTER_NAME}

--- a/examples/strimzi/cloud/kafka-connect.yaml
+++ b/examples/strimzi/cloud/kafka-connect.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaConnect
 metadata:
   name: axonops-connect

--- a/examples/strimzi/cloud/kafka-node-pool-brokers.yaml
+++ b/examples/strimzi/cloud/kafka-node-pool-brokers.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: axonops-brokers

--- a/examples/strimzi/cloud/kafka-node-pool-controller.yaml
+++ b/examples/strimzi/cloud/kafka-node-pool-controller.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: axonops-controller

--- a/examples/strimzi/local-disk/strimzi-broker-pools.yaml
+++ b/examples/strimzi/local-disk/strimzi-broker-pools.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: broker-pool

--- a/examples/strimzi/local-disk/strimzi-controller-pools.yaml
+++ b/examples/strimzi/local-disk/strimzi-controller-pools.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: ${STRIMZI_CLUSTER_NAME}-controller

--- a/examples/strimzi/local-disk/strimzi-kafka-cluster.yaml
+++ b/examples/strimzi/local-disk/strimzi-kafka-cluster.yaml
@@ -1,4 +1,4 @@
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: ${STRIMZI_CLUSTER_NAME}

--- a/examples/strimzi/on-premises/kafka-cluster.yaml
+++ b/examples/strimzi/on-premises/kafka-cluster.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: Kafka
 metadata:
   name: ${STRIMZI_CLUSTER_NAME}

--- a/examples/strimzi/on-premises/kafka-connect.yaml
+++ b/examples/strimzi/on-premises/kafka-connect.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaConnect
 metadata:
   name: axonops-connect

--- a/examples/strimzi/on-premises/kafka-node-pool-brokers.yaml
+++ b/examples/strimzi/on-premises/kafka-node-pool-brokers.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: axonops-brokers

--- a/examples/strimzi/on-premises/kafka-node-pool-controller.yaml
+++ b/examples/strimzi/on-premises/kafka-node-pool-controller.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: kafka.strimzi.io/v1beta2
+apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
   name: axonops-controller

--- a/k8ssandra/4.0/axonops-entrypoint.sh
+++ b/k8ssandra/4.0/axonops-entrypoint.sh
@@ -39,9 +39,43 @@ if [ ! -f /etc/axonops/axon-agent.yml ]; then
   echo "# intentionally left empty" >> /etc/axonops/axon-agent.yml
 fi
 
-/usr/share/axonops/axon-agent $AXON_AGENT_ARGS | tee /var/log/axonops/axon-agent.log 2>&1 &
-/docker-entrypoint.sh mgmtapi &
+# Supervise axon-agent: restart forever on exit, with crash-loop backoff (issue #154).
+# Runs as a backgrounded subshell so the container lifecycle stays tied to the
+# Management API, not the agent. The agent is piped through tee, so its real exit
+# code is read from PIPESTATUS, not $?.
+supervise_axon_agent() {
+  local log="/var/log/axonops/axon-agent.log"
+  local fails=0
+  local window
+  window=$(date +%s)
+  while true; do
+    echo "[axonops-supervise] starting axon-agent" | tee -a "$log" 2>/dev/null
+    /usr/share/axonops/axon-agent $AXON_AGENT_ARGS 2>&1 | tee -a "$log" 2>/dev/null
+    local rc=${PIPESTATUS[0]}
+    echo "[axonops-supervise] axon-agent exited rc=${rc}, restarting" | tee -a "$log" 2>/dev/null
+    local now
+    now=$(date +%s)
+    if [ $((now - window)) -gt 60 ]; then
+      fails=0
+      window=$now
+    fi
+    fails=$((fails + 1))
+    if [ "$fails" -gt 5 ]; then
+      echo "[axonops-supervise] >5 restarts in 60s, backing off 30s" | tee -a "$log" 2>/dev/null
+      sleep 30
+      fails=0
+      window=$(date +%s)
+    else
+      sleep 2
+    fi
+  done
+}
 
-wait -n
-# Exit with status of process that exited first
+supervise_axon_agent &
+
+/docker-entrypoint.sh mgmtapi &
+MGMTAPI_PID=$!
+
+# Keep the container tied to the Management API; exit with its status when it dies.
+wait "$MGMTAPI_PID"
 exit $?

--- a/k8ssandra/4.1/axonops-entrypoint.sh
+++ b/k8ssandra/4.1/axonops-entrypoint.sh
@@ -39,9 +39,43 @@ if [ ! -f /etc/axonops/axon-agent.yml ]; then
   echo "# intentionally left empty" >> /etc/axonops/axon-agent.yml
 fi
 
-/usr/share/axonops/axon-agent $AXON_AGENT_ARGS | tee /var/log/axonops/axon-agent.log 2>&1 &
-/docker-entrypoint.sh mgmtapi &
+# Supervise axon-agent: restart forever on exit, with crash-loop backoff (issue #154).
+# Runs as a backgrounded subshell so the container lifecycle stays tied to the
+# Management API, not the agent. The agent is piped through tee, so its real exit
+# code is read from PIPESTATUS, not $?.
+supervise_axon_agent() {
+  local log="/var/log/axonops/axon-agent.log"
+  local fails=0
+  local window
+  window=$(date +%s)
+  while true; do
+    echo "[axonops-supervise] starting axon-agent" | tee -a "$log" 2>/dev/null
+    /usr/share/axonops/axon-agent $AXON_AGENT_ARGS 2>&1 | tee -a "$log" 2>/dev/null
+    local rc=${PIPESTATUS[0]}
+    echo "[axonops-supervise] axon-agent exited rc=${rc}, restarting" | tee -a "$log" 2>/dev/null
+    local now
+    now=$(date +%s)
+    if [ $((now - window)) -gt 60 ]; then
+      fails=0
+      window=$now
+    fi
+    fails=$((fails + 1))
+    if [ "$fails" -gt 5 ]; then
+      echo "[axonops-supervise] >5 restarts in 60s, backing off 30s" | tee -a "$log" 2>/dev/null
+      sleep 30
+      fails=0
+      window=$(date +%s)
+    else
+      sleep 2
+    fi
+  done
+}
 
-wait -n
-# Exit with status of process that exited first
+supervise_axon_agent &
+
+/docker-entrypoint.sh mgmtapi &
+MGMTAPI_PID=$!
+
+# Keep the container tied to the Management API; exit with its status when it dies.
+wait "$MGMTAPI_PID"
 exit $?

--- a/k8ssandra/5.0/axonops-entrypoint.sh
+++ b/k8ssandra/5.0/axonops-entrypoint.sh
@@ -160,8 +160,40 @@ while true; do
 done
 echo "Cassandra is ready, starting axon-agent"
 
-# Start axon-agent in background
-/usr/share/axonops/axon-agent $AXON_AGENT_ARGS 2>&1 | tee /var/log/axonops/axon-agent.log &
+# Supervise axon-agent: restart forever on exit, with crash-loop backoff (issue #154).
+# Runs as a backgrounded subshell so the container lifecycle stays tied to the
+# Management API, not the agent. The agent is piped through tee, so its real exit
+# code is read from PIPESTATUS, not $?.
+supervise_axon_agent() {
+  local log="/var/log/axonops/axon-agent.log"
+  local fails=0
+  local window
+  window=$(date +%s)
+  while true; do
+    echo "[axonops-supervise] starting axon-agent" | tee -a "$log" 2>/dev/null
+    /usr/share/axonops/axon-agent $AXON_AGENT_ARGS 2>&1 | tee -a "$log" 2>/dev/null
+    local rc=${PIPESTATUS[0]}
+    echo "[axonops-supervise] axon-agent exited rc=${rc}, restarting" | tee -a "$log" 2>/dev/null
+    local now
+    now=$(date +%s)
+    if [ $((now - window)) -gt 60 ]; then
+      fails=0
+      window=$now
+    fi
+    fails=$((fails + 1))
+    if [ "$fails" -gt 5 ]; then
+      echo "[axonops-supervise] >5 restarts in 60s, backing off 30s" | tee -a "$log" 2>/dev/null
+      sleep 30
+      fails=0
+      window=$(date +%s)
+    else
+      sleep 2
+    fi
+  done
+}
+
+# Start axon-agent under supervision in the background
+supervise_axon_agent &
 
 # Wait on Management API process to keep container running
 wait $MGMTAPI_PID

--- a/k8ssandra/scripts/set_latest_k8ssandra_version.sh
+++ b/k8ssandra/scripts/set_latest_k8ssandra_version.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Sets the K8SSANDRA_VERSION GitHub Actions variable to the latest Cassandra
+# version found in the K8SSANDRA_VERSIONS repository variable.
+#
+# Usage:
+#   ./set_latest_k8ssandra_version.sh [--repo OWNER/REPO] [--dry-run]
+#
+# Requirements: gh CLI authenticated, jq
+
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-axonops/axonops-containers}"
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)   REPO="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+echo "Fetching K8SSANDRA_VERSIONS from ${REPO}..."
+VERSIONS_JSON=$(gh variable get K8SSANDRA_VERSIONS --repo "$REPO" --json value -q .value)
+
+if [ -z "$VERSIONS_JSON" ]; then
+  echo "ERROR: K8SSANDRA_VERSIONS variable is empty or not set" >&2
+  exit 1
+fi
+
+# Keys are "CASSANDRA_VER+API_VER" (e.g. "5.0.7+0.1.113").
+# Extract the Cassandra part and find the highest semver.
+LATEST=$(echo "$VERSIONS_JSON" | jq -r '
+  keys[]
+  | split("+")[0]
+' | sort -V | tail -1)
+
+if [ -z "$LATEST" ]; then
+  echo "ERROR: Could not determine latest version" >&2
+  exit 1
+fi
+
+echo "Latest Cassandra version: ${LATEST}"
+
+if [ "$DRY_RUN" = true ]; then
+  echo "[dry-run] Would set K8SSANDRA_VERSION=${LATEST} on ${REPO}"
+  exit 0
+fi
+
+gh variable set K8SSANDRA_VERSION --body "$LATEST" --repo "$REPO"
+echo "✓ K8SSANDRA_VERSION=${LATEST} set on ${REPO}"

--- a/strimzi/files/axonops-wrapper.sh
+++ b/strimzi/files/axonops-wrapper.sh
@@ -47,5 +47,38 @@ if [ "$KAFKA_NODE_TYPE" = "kraft-controller" ]; then
     ln -s /var/log/kafka/server.log /var/log/kafka/controller.log
 fi
 
-# Start the agent
-/usr/share/axonops/axon-agent -o file $AGENT_ARGS &
+# Supervise axon-agent: restart forever on exit, with crash-loop backoff (issue #154).
+# This wrapper is sourced into the Strimzi run script, which then execs the Kafka
+# JVM (replacing this shell). Backgrounding the supervisor lets it survive that
+# exec: it is reparented to PID 1 (tini), which reaps the agent's exits. Log lines
+# go to stdout (Kafka logs); the file tee degrades gracefully if not writable.
+supervise_axon_agent() {
+  local log="/var/log/axonops/axon-agent.log"
+  local fails=0
+  local window
+  window=$(date +%s)
+  while true; do
+    echo "[axonops-supervise] starting axon-agent" | tee -a "$log" 2>/dev/null
+    /usr/share/axonops/axon-agent -o file $AGENT_ARGS 2>&1 | tee -a "$log" 2>/dev/null
+    local rc=${PIPESTATUS[0]}
+    echo "[axonops-supervise] axon-agent exited rc=${rc}, restarting" | tee -a "$log" 2>/dev/null
+    local now
+    now=$(date +%s)
+    if [ $((now - window)) -gt 60 ]; then
+      fails=0
+      window=$now
+    fi
+    fails=$((fails + 1))
+    if [ "$fails" -gt 5 ]; then
+      echo "[axonops-supervise] >5 restarts in 60s, backing off 30s" | tee -a "$log" 2>/dev/null
+      sleep 30
+      fails=0
+      window=$(date +%s)
+    else
+      sleep 2
+    fi
+  done
+}
+
+# Start the agent under supervision, backgrounded so it survives the Kafka exec
+supervise_axon_agent &


### PR DESCRIPTION
## Summary

Three related container/example maintenance changes on this branch:

1. **`axon-agent` supervision & auto-restart** (`2912467`) — the `axon-agent` sidecar in the k8ssandra (`4.0/4.1/5.0`) and strimzi container images is now supervised and restarted automatically if it exits, with crash-loop protection (>5 restarts in 60s → 30s backoff) and death/restart events logged to stdout and `/var/log/axonops/axon-agent.log`. Previously a dead agent was never detected for the life of the container. Closes [#154](https://github.com/axonops/axonops-containers/issues/154).
2. **Strimzi example manifests → `apiVersion: kafka.strimzi.io/v1`** (`6ac4088`) — bumps the 11 example manifests under `examples/strimzi/{cloud,local-disk,on-premises}/` from `v1beta2` to `v1` for `Kafka`, `KafkaConnect` and `KafkaNodePool`.
3. **`set_latest_k8ssandra_version.sh`** (`91f1925`) — helper that reads the `K8SSANDRA_VERSIONS` GHA repo variable and sets `K8SSANDRA_VERSION` to the highest Cassandra semver. Supports `--repo` and `--dry-run`.

## Why the Strimzi v1 bump

The `v1` API is served by Strimzi operator **≥0.49.0** and is the **only** version served from **1.0.1** onwards (where `v1beta2` is dropped). The build matrix recently gained operators 1.0.1 and 1.1.0 (#152), so the examples had to move to `v1` to keep working against them.

**CI-safe:** the only workflow that applies these manifests, `strimzi-cloud-install-test.yml`, runs against operator `0.50.0` (≥0.49.0), so `v1` is served. The `0.47.0` default in `strimzi-development-build-and-test.yml` only builds images and never applies the examples.

**Prerequisite for users:** the examples now require Strimzi operator ≥0.49.0.

## Notes

- `set_latest_k8ssandra_version.sh` is CI-oriented (`gh` + `jq`, GNU `sort -V`). Non-blocking review nits (no explicit `gh`/`jq` presence check, no `--help`, GNU-only `sort -V` on stock macOS) were left out to keep scope tight; can follow up if wanted.

## Testing

- Strimzi manifests: KRaft-only (`strimzi.io/kraft: enabled`, node-pools, no `zookeeper` block) — matches the `v1` CRD schema; no other fields required changes.
- Secrets audit: clean (no plaintext secrets in the diff).

## Gates

- CHANGELOG updated (`Added` + `Changed`).
- secrets-auditor: PASS.
- kafka-config-reviewer: `v1` confirmed correct for operator ≥0.49.0; CI applies against 0.50.0.
- shell-script-reviewer: no blocking issues.

Assisted-by: Claude Code