### PR TITLE
fix(ci): verify and sign before tagging published images

### DIFF
--- a/.github/workflows/cassandra-publish-signed.yml
+++ b/.github/workflows/cassandra-publish-signed.yml
@@ -302,20 +302,16 @@ jobs:
           current_version: ${{ matrix.cassandra_version }}
           all_versions: ${{ env.ALL_VERSIONS }}
 
-      - name: Build and push Docker image
+      # Pushed by digest only: no tag exists until the image has passed its
+      # tests and been signed, so a failure here leaves nothing pullable.
+      - name: Build and push by digest (untagged)
         id: build
         uses: docker/build-push-action@v5
         with:
           context: ./k8ssandra/${{ steps.version.outputs.base_version }}
           file: ./k8ssandra/${{ steps.version.outputs.base_version }}/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}-${{ env.AGENT_VERSION }}-${{ inputs.container_version }}
-            ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}-${{ env.AGENT_VERSION }}
-            ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}
-            ${{ steps.version.outputs.is_minor_latest == 'true' && format('ghcr.io/{0}:{1}-latest', env.IMAGE_NAME, steps.version.outputs.base_version) || '' }}
-            ${{ steps.version.outputs.is_global_latest == 'true' && format('ghcr.io/{0}:latest', env.IMAGE_NAME) || '' }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           annotations: |
             index:org.opencontainers.image.created=${{ github.event.repository.updated_at }}
             index:org.opencontainers.image.authors=AxonOps
@@ -399,7 +395,39 @@ jobs:
         with:
           image: ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
 
+      # Tags are applied last, to an image that is already tested and signed.
+      # imagetools create copies the index without rebuilding, so every tag
+      # resolves to exactly the digest that was signed - asserted below.
+      - name: Apply tags to the verified image
+        env:
+          IMAGE: ghcr.io/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAG_IMMUTABLE: ${{ matrix.cassandra_version }}-${{ env.AGENT_VERSION }}-${{ inputs.container_version }}
+          TAG_PAIR: ${{ matrix.cassandra_version }}-${{ env.AGENT_VERSION }}
+          TAG_CASSANDRA: ${{ matrix.cassandra_version }}
+          TAG_MINOR_LATEST: ${{ steps.version.outputs.is_minor_latest == 'true' && format('{0}-latest', steps.version.outputs.base_version) || '' }}
+          TAG_GLOBAL_LATEST: ${{ steps.version.outputs.is_global_latest == 'true' && 'latest' || '' }}
+        run: |
+          TAGS=()
+          for TAG in "$TAG_IMMUTABLE" "$TAG_PAIR" "$TAG_CASSANDRA" "$TAG_MINOR_LATEST" "$TAG_GLOBAL_LATEST"; do
+            if [ -n "$TAG" ]; then TAGS+=("$TAG"); fi
+          done
+
+          ARGS=()
+          for TAG in "${TAGS[@]}"; do ARGS+=(-t "${IMAGE}:${TAG}"); done
+          docker buildx imagetools create "${ARGS[@]}" "${IMAGE}@${DIGEST}"
+
+          for TAG in "${TAGS[@]}"; do
+            RESOLVED=$(docker buildx imagetools inspect "${IMAGE}:${TAG}" --format '{{ .Manifest.Digest }}')
+            if [ "$RESOLVED" != "$DIGEST" ]; then
+              echo "ERROR: ${IMAGE}:${TAG} resolves to ${RESOLVED}, expected the signed digest ${DIGEST}"
+              exit 1
+            fi
+            echo "${IMAGE}:${TAG} -> ${DIGEST}"
+          done
+
       - name: Image published and signed
         run: |
           echo "Published and signed:"
           echo "  ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}-${{ env.AGENT_VERSION }}-${{ inputs.container_version }}"
+          echo "  digest ${{ steps.build.outputs.digest }}"

--- a/.github/workflows/k8ssandra-publish-signed.yml
+++ b/.github/workflows/k8ssandra-publish-signed.yml
@@ -302,20 +302,16 @@ jobs:
           current_version: ${{ matrix.cassandra_version }}
           all_versions: ${{ env.ALL_VERSIONS }}
 
-      - name: Build and push Docker image
+      # Pushed by digest only: no tag exists until the image has passed its
+      # tests and been signed, so a failure here leaves nothing pullable.
+      - name: Build and push by digest (untagged)
         id: build
         uses: docker/build-push-action@v5
         with:
           context: ./k8ssandra/${{ steps.version.outputs.base_version }}
           file: ./k8ssandra/${{ steps.version.outputs.base_version }}/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}-v${{ steps.k8ssandra.outputs.k8ssandra_api_version }}-${{ inputs.container_version }}
-            ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}-v${{ steps.k8ssandra.outputs.k8ssandra_api_version }}
-            ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}
-            ${{ steps.version.outputs.is_minor_latest == 'true' && format('ghcr.io/{0}:{1}-latest', env.IMAGE_NAME, steps.version.outputs.base_version) || '' }}
-            ${{ steps.version.outputs.is_global_latest == 'true' && format('ghcr.io/{0}:latest', env.IMAGE_NAME) || '' }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           annotations: |
             index:org.opencontainers.image.created=${{ github.event.repository.updated_at }}
             index:org.opencontainers.image.authors=AxonOps
@@ -400,52 +396,37 @@ jobs:
         with:
           image: ghcr.io/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
 
-      - name: Re-push tags after signing
-        uses: docker/build-push-action@v5
-        with:
-          context: ./k8ssandra/${{ steps.version.outputs.base_version }}
-          file: ./k8ssandra/${{ steps.version.outputs.base_version }}/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}-v${{ steps.k8ssandra.outputs.k8ssandra_api_version }}-${{ inputs.container_version }}
-            ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}-v${{ steps.k8ssandra.outputs.k8ssandra_api_version }}
-            ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}
-            ${{ steps.version.outputs.is_minor_latest == 'true' && format('ghcr.io/{0}:{1}-latest', env.IMAGE_NAME, steps.version.outputs.base_version) || '' }}
-            ${{ steps.version.outputs.is_global_latest == 'true' && format('ghcr.io/{0}:latest', env.IMAGE_NAME) || '' }}
-          annotations: |
-            index:org.opencontainers.image.created=${{ github.event.repository.updated_at }}
-            index:org.opencontainers.image.authors=AxonOps
-            index:org.opencontainers.image.url=https://axonops.com
-            index:org.opencontainers.image.documentation=https://github.com/axonops/axonops-containers/blob/main/k8ssandra/README.md
-            index:org.opencontainers.image.source=https://github.com/axonops/axonops-containers
-            index:org.opencontainers.image.version=${{ inputs.container_version }}
-            index:org.opencontainers.image.revision=${{ github.sha }}
-            index:org.opencontainers.image.vendor=AxonOps
-            index:org.opencontainers.image.licenses=Apache-2.0
-            index:org.opencontainers.image.title=AxonOps K8ssandra Apache Cassandra ${{ matrix.cassandra_version }}
-            index:org.opencontainers.image.description=Apache Cassandra ${{ matrix.cassandra_version }} + k8ssandra API v${{ steps.k8ssandra.outputs.k8ssandra_api_version }} + AxonOps monitoring + cqlai v${{ vars.K8SSANDRA_CQLAI_VERSION }}. Multi-arch (amd64/arm64), signed with cosign, optimized for Kubernetes.
-            index:org.opencontainers.image.ref.name=ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}-v${{ steps.k8ssandra.outputs.k8ssandra_api_version }}-${{ inputs.container_version }}
-            index:org.opencontainers.image.base.name=docker.io/k8ssandra/cass-management-api:${{ matrix.cassandra_version }}-ubi-v${{ steps.k8ssandra.outputs.k8ssandra_api_version }}
-            index:org.opencontainers.image.base.digest=${{ steps.k8ssandra.outputs.digest }}
-            index:com.axonops.cassandra.version=${{ matrix.cassandra_version }}
-            index:com.axonops.k8ssandra-api.version=${{ steps.k8ssandra.outputs.k8ssandra_api_version }}
-            index:com.axonops.cqlai.version=${{ vars.K8SSANDRA_CQLAI_VERSION }}
-            index:com.axonops.build.actor=${{ github.actor }}
-          build-args: |
-            CASSANDRA_VERSION=${{ matrix.cassandra_version }}
-            MAJOR_VERSION=${{ steps.version.outputs.base_version }}
-            K8SSANDRA_BASE_DIGEST=${{ steps.k8ssandra.outputs.digest }}
-            K8SSANDRA_API_VERSION=${{ steps.k8ssandra.outputs.k8ssandra_api_version }}
-            BUILD_DATE=${{ github.event.repository.updated_at }}
-            VCS_REF=${{ github.sha }}
-            VERSION=${{ inputs.container_version }}
-            GIT_TAG=${{ inputs.main_git_tag }}
-            GITHUB_ACTOR=${{ github.actor }}
-            CQLAI_VERSION=${{ vars.K8SSANDRA_CQLAI_VERSION }}
-            IS_PRODUCTION_RELEASE=true
-            IMAGE_FULL_NAME=ghcr.io/${{ env.IMAGE_NAME }}:${{ matrix.cassandra_version }}-v${{ steps.k8ssandra.outputs.k8ssandra_api_version }}-${{ inputs.container_version }}
-          cache-from: type=gha
+      # Tags are applied last, to an image that is already tested and signed.
+      # imagetools create copies the index without rebuilding - the previous
+      # implementation re-ran the whole multi-arch build here - so every tag
+      # resolves to exactly the digest that was signed, asserted below.
+      - name: Apply tags to the verified image
+        env:
+          IMAGE: ghcr.io/${{ env.IMAGE_NAME }}
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAG_IMMUTABLE: ${{ matrix.cassandra_version }}-v${{ steps.k8ssandra.outputs.k8ssandra_api_version }}-${{ inputs.container_version }}
+          TAG_API: ${{ matrix.cassandra_version }}-v${{ steps.k8ssandra.outputs.k8ssandra_api_version }}
+          TAG_CASSANDRA: ${{ matrix.cassandra_version }}
+          TAG_MINOR_LATEST: ${{ steps.version.outputs.is_minor_latest == 'true' && format('{0}-latest', steps.version.outputs.base_version) || '' }}
+          TAG_GLOBAL_LATEST: ${{ steps.version.outputs.is_global_latest == 'true' && 'latest' || '' }}
+        run: |
+          TAGS=()
+          for TAG in "$TAG_IMMUTABLE" "$TAG_API" "$TAG_CASSANDRA" "$TAG_MINOR_LATEST" "$TAG_GLOBAL_LATEST"; do
+            if [ -n "$TAG" ]; then TAGS+=("$TAG"); fi
+          done
+
+          ARGS=()
+          for TAG in "${TAGS[@]}"; do ARGS+=(-t "${IMAGE}:${TAG}"); done
+          docker buildx imagetools create "${ARGS[@]}" "${IMAGE}@${DIGEST}"
+
+          for TAG in "${TAGS[@]}"; do
+            RESOLVED=$(docker buildx imagetools inspect "${IMAGE}:${TAG}" --format '{{ .Manifest.Digest }}')
+            if [ "$RESOLVED" != "$DIGEST" ]; then
+              echo "ERROR: ${IMAGE}:${TAG} resolves to ${RESOLVED}, expected the signed digest ${DIGEST}"
+              exit 1
+            fi
+            echo "${IMAGE}:${TAG} -> ${DIGEST}"
+          done
 
       - name: Image published and signed
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `cassandra-publish-signed` and `k8ssandra-publish-signed` pushed tagged images *before* running their verification steps, so any post-push failure left published tags that were never verified and never signed. This happened on the Cassandra 1.0.0 run: 5.0.3 was pushed, failed its cqlai test, skipped signing, and sat in the registry unsigned. Both pipelines now push by digest only, run the test suite, sign the digest, and apply tags last with `docker buildx imagetools create` — asserting that every tag resolves to the digest that was signed. A failure at any stage now leaves nothing pullable by tag.
+- `k8ssandra-publish-signed` re-ran the entire multi-arch build after signing purely to re-apply tags. That second build is gone; tagging copies the existing index instead.
+
+### Fixed
 - `k8ssandra-test-cqlai` verified query output by piping `cqlai` straight into `grep -q`. `grep -q` exits on the first match, SIGPIPEs `cqlai`, and under `pipefail` the step fails with exit 141 whenever the write loses the race — it took out a Cassandra 5.0.3 publish job. The output is now captured before matching.
 - `fail-fast` disabled on the `cassandra-publish-signed` and `k8ssandra-publish-signed` build matrices. One version failing was cancelling every other version mid-publish, which can leave a release half-pushed with inconsistent floating tags.
 


### PR DESCRIPTION
Closes the hole that let an unverified, unsigned Cassandra 5.0.3 go public during the 1.0.0 release.

## The problem

Both publish pipelines had this order:

```
7.  Build and push Docker image  -> pushes ALL tags
12. Test cqlai                   -> failed
15. Sign container image         -> skipped
```

The image is public from step 7. Anything failing after that leaves tags nobody verified and cosign never signed. On [run 31703459836](https://github.com/axonops/axonops-containers/actions/runs/31703459836) that produced `ghcr.io/axonops/cassandra/cassandra:5.0.3`, `:5.0.3-2.0.31` and `:5.0.3-2.0.31-1.0.0`, unsigned, from a build that failed its tests. Worse in principle: `latest` and `5.0-latest` are pushed by the same step, so a failure in the 5.0.8 job would have left the floating tags pointing at an unverified build.

## The fix

```
build + push by digest (push-by-digest=true, no tags)
  -> pull by digest, run the full test suite
  -> cosign sign the digest
  -> apply tags with `docker buildx imagetools create`
  -> assert every tag resolves to the signed digest
```

If anything fails, the registry holds an untagged manifest that no tag points at — invisible to anyone pulling by tag — instead of a published image.

The tag-application step is explicit about what it asserts:

```bash
docker buildx imagetools create "${ARGS[@]}" "${IMAGE}@${DIGEST}"
for TAG in "${TAGS[@]}"; do
  RESOLVED=$(docker buildx imagetools inspect "${IMAGE}:${TAG}" --format '{{ .Manifest.Digest }}')
  [ "$RESOLVED" = "$DIGEST" ] || exit 1
done
```

## Bonus: one less full build

`k8ssandra-publish-signed` had a "Re-push tags after signing" step that re-ran the entire multi-arch build to re-apply the tags. That is gone — `imagetools create` copies the existing index. Each k8ssandra matrix job now builds once instead of twice.

## Scope

- `.github/workflows/cassandra-publish-signed.yml`
- `.github/workflows/k8ssandra-publish-signed.yml`

The development pipelines still push tags directly; they publish to `axonops/development/*` where an unverified tag is far less consequential. Worth doing later for consistency.

## Testing

- `actionlint` clean on both workflows.
- Not exercised end to end yet: proving it needs a production run, and the Cassandra 1.0.0 release is already out. The next release of either image is the real test. The behaviour under failure is the part worth reviewing carefully — if `imagetools create` is never reached, no tag ever moves.

## Cleanup note

Failed runs will now leave untagged manifests in GHCR. They are unreferenced and harmless, but a periodic prune of untagged versions would keep the package tidy.

Assisted-by: Claude Code